### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
     timezone: Europe/Lisbon
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
   ignore:
   - dependency-name: "@types/node"
     versions:


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.